### PR TITLE
Extended api

### DIFF
--- a/lupng.c
+++ b/lupng.c
@@ -1157,7 +1157,8 @@ void luImageRelease(LuImage *img, const LuUserContext *userCtx)
     }
 
     userCtx->freeProc(img->data, userCtx->freeProcUserPtr);
-    userCtx->freeProc(img, userCtx->freeProcUserPtr);
+    if (userCtx->overrideImage != img)
+        userCtx->freeProc(img, userCtx->freeProcUserPtr);
 }
 
 LuImage *luImageCreate(size_t width, size_t height, uint8_t channels, uint8_t depth,
@@ -1177,7 +1178,10 @@ LuImage *luImageCreate(size_t width, size_t height, uint8_t channels, uint8_t de
         return NULL;
     }
 
-    img = (LuImage *)userCtx->allocProc(sizeof(LuImage), userCtx->allocProcUserPtr);
+    if (userCtx->overrideImage)
+        img = userCtx->overrideImage;
+    else
+        img = (LuImage *)userCtx->allocProc(sizeof(LuImage), userCtx->allocProcUserPtr);
     if (!img)
         return NULL;
 
@@ -1238,4 +1242,6 @@ void luUserContextInitDefault(LuUserContext *userCtx)
 
     userCtx->warnProc=internalPrintf;
     userCtx->warnProcUserPtr=(void*)stderr;
+
+    userCtx->overrideImage=NULL;
 }

--- a/lupng.c
+++ b/lupng.c
@@ -468,7 +468,7 @@ static inline int parseIhdr(PngInfoStruct *info, PngChunk *chunk)
         return PNG_ERROR;
     }
     info->img = luImageCreate(info->width, info->height,
-                              info->channels, info->depth < 16 ? 8 : 16, info->userCtx);
+                              info->channels, info->depth < 16 ? 8 : 16, NULL, info->userCtx);
     info->cimg = info->img;
     info->scanlineBytes = MAX((info->width * info->channels * info->depth) >> 3, 1);
     info->currentScanline = (uint8_t *)info->userCtx->allocProc(info->scanlineBytes, info->userCtx->allocProcUserPtr);
@@ -1160,7 +1160,8 @@ void luImageRelease(LuImage *img, const LuUserContext *userCtx)
     userCtx->freeProc(img, userCtx->freeProcUserPtr);
 }
 
-LuImage *luImageCreate(size_t width, size_t height, uint8_t channels, uint8_t depth, const LuUserContext *userCtx)
+LuImage *luImageCreate(size_t width, size_t height, uint8_t channels, uint8_t depth,
+                       uint8_t *buffer, const LuUserContext *userCtx)
 {
     LuImage *img;
     LuUserContext ucDefault;
@@ -1185,7 +1186,10 @@ LuImage *luImageCreate(size_t width, size_t height, uint8_t channels, uint8_t de
     img->channels = channels;
     img->depth = depth;
     img->dataSize = (size_t)((depth >> 3) * width * height * channels);
-    img->data = (uint8_t *)userCtx->allocProc(img->dataSize, userCtx->allocProcUserPtr);
+    if (buffer)
+        img->data = buffer;
+    else
+        img->data = (uint8_t *)userCtx->allocProc(img->dataSize, userCtx->allocProcUserPtr);
 
     if (img->data == NULL)
     {

--- a/lupng.h
+++ b/lupng.h
@@ -78,11 +78,14 @@ void luUserContextInitDefault(LuUserContext *userCtx);
  * The data store of the Image is allocated but its contents are undefined.
  * Only 8 and 16 bits deep images with 1-4 channels are supported.
  *
+ * @param buffer pointer to an existing buffer (which may already contain the
+ *               image data), or NULL to internally allocate a new buffer
  * @param userCtx the user context (with the memory allocator function
  *                pointers to use), or NULL to use the default allocator
  *                (malloc).
  */
-LuImage *luImageCreate(size_t width, size_t height, uint8_t channels, uint8_t depth, const LuUserContext *usrCtx);
+LuImage *luImageCreate(size_t width, size_t height, uint8_t channels, uint8_t depth,
+                       uint8_t *buffer, const LuUserContext *usrCtx);
 
 /**
  * Releases the memory associated with the given Image object.

--- a/lupng.h
+++ b/lupng.h
@@ -64,6 +64,10 @@ typedef struct {
     /* warnings/error output */
     PngWarnProc warnProc; /* set to NULL to disable output altogether */
     void *warnProcUserPtr;
+
+    /* special case: avoid allocating a LuImage when loading or creating
+     * an image, just use this one */
+    LuImage *overrideImage;
 } LuUserContext;
 
 /**


### PR DESCRIPTION
I extended the API so that a LuImage can be created for an existing image, which I need for saving images with LuPng.

I also added a way to avoid dynamically allocating the LuPng struct and to work with a user-provided one instead. Since I need the LuImage struct only temporarily for loading and saving, but have my own image structures it is more efficient to work with a local variables on the stack... That feature is probably not very important, but I hate unnecessary malloc()s :)
